### PR TITLE
Upgrade Xeno-Canto downloader to the v3 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ pip install -r requirements.txt
 
 ## Download and Prepare Data
 
+### Xeno-Canto API key
+
+Xeno-Canto's old keyless v2 API no longer works (requests to `api/2/...` now
+return HTTP 404). The current [v3 API](https://xeno-canto.org/explore/api)
+requires a free key — a keyless request returns `HTTP 401` with
+`"Missing or invalid 'key' parameter"`. Create a key at
+[xeno-canto.org/account](https://xeno-canto.org/account) and export it before
+downloading:
+
+```
+export XENO_CANTO_API_KEY=your_key_here
+```
+
+Without a key, the Macaulay downloads still run and Xeno-Canto is skipped with a
+notice.
+
 For a new user, start with the small `starter` dataset:
 
 ```

--- a/downloader/download_crows_xeno.py
+++ b/downloader/download_crows_xeno.py
@@ -1,47 +1,83 @@
-import requests
 import csv
 import os
 from datetime import datetime
+
+import requests
 
 from crowtools.datasets import get_library_dir
 
 PATH = os.path.dirname(__file__)
 
 # -- CONFIG: Adjust as needed --
-SPECIES_QUERY = "American+Crow"
-BASE_API_URL = "https://www.xeno-canto.org/api/2/recordings"
+# Xeno-canto retired the keyless v2 API; v3 is the current endpoint and needs a
+# free API key (https://xeno-canto.org/account). v3 also expects tag-based
+# queries, so the species is given as gen:/sp: rather than a free-text name.
+SPECIES_QUERY = "gen:Corvus sp:brachyrhynchos"
+BASE_API_URL = "https://xeno-canto.org/api/3/recordings"
+API_KEY_ENV_VAR = "XENO_CANTO_API_KEY"
 
-def fetch_all_recordings(query):
+
+def resolve_api_key(api_key=None):
+    return api_key or os.environ.get(API_KEY_ENV_VAR)
+
+
+def fetch_all_recordings(query, api_key):
     """
-    Fetch all pages from Xeno-Canto API for the given query (species).
+    Fetch all pages from the Xeno-Canto v3 API for the given query.
     Returns a list of recording dictionaries.
     """
     all_recs = []
     page_number = 1
 
     while True:
-        url = f"{BASE_API_URL}?query={query}&page={page_number}"
-        resp = requests.get(url).json()
-        recs = resp.get("recordings", [])
+        resp = requests.get(
+            BASE_API_URL,
+            params={"query": query, "key": api_key, "page": page_number},
+            timeout=30,
+        )
+        if resp.status_code != 200:
+            detail = resp.text[:200].replace("\n", " ")
+            print(f"Xeno-Canto API returned HTTP {resp.status_code}: {detail}")
+            break
+
+        data = resp.json()
+        recs = data.get("recordings", [])
         if not recs:
             break
 
         all_recs.extend(recs)
 
         # Stop if we reached the last page
-        if page_number >= int(resp["numPages"]):
+        if page_number >= int(data.get("numPages", 1)):
             break
 
         page_number += 1
 
     return all_recs
 
+
+def recording_file_url(rec):
+    """Pull the downloadable audio URL out of a v3 recording, fixing the scheme.
+
+    v3 usually returns `file` as a URL string, but has been seen to nest it as
+    {"url": ...}; handle both so a format tweak upstream doesn't break ingest.
+    """
+    file_url = rec.get("file")
+    if isinstance(file_url, dict):
+        file_url = file_url.get("url")
+    if not file_url:
+        return ""
+    if file_url.startswith("//"):
+        file_url = "https:" + file_url
+    return file_url
+
+
 def download_mp3(xc_id, mp3_url, output_dir):
     """
     Download MP3 file to local OUTPUT_DIR/{xc_id}.mp3
     """
-    if mp3_url.startswith("//"):
-        mp3_url = "https:" + mp3_url  # Fix if it starts with //
+    if not mp3_url:
+        return
 
     filename = f"{xc_id}.mp3"
     filepath = os.path.join(output_dir, filename)
@@ -55,14 +91,24 @@ def download_mp3(xc_id, mp3_url, output_dir):
         except Exception as e:
             print(f"Error downloading {mp3_url}: {e}")
 
-def start_downloads(percent=100, selected_ids=None, cache_base=None):
+
+def start_downloads(percent=100, selected_ids=None, cache_base=None, api_key=None):
+    api_key = resolve_api_key(api_key)
+    if not api_key:
+        print(
+            "No Xeno-Canto API key found. The v3 API requires a free key: create "
+            "one at https://xeno-canto.org/account and set the "
+            f"{API_KEY_ENV_VAR} environment variable. Skipping Xeno-Canto."
+        )
+        return
+
     library_base = get_library_dir("xeno-canto", cache_base)
     output_csv = os.path.join(library_base, "library.csv")
     output_dir = os.path.join(library_base, "audio")
     os.makedirs(output_dir, exist_ok=True)
 
     # Fetch all recordings
-    recordings = fetch_all_recordings(SPECIES_QUERY)
+    recordings = fetch_all_recordings(SPECIES_QUERY, api_key)
     print(f"Found {len(recordings)} recordings for '{SPECIES_QUERY}'.")
     if selected_ids is not None:
         selected_lookup = {str(value) for value in selected_ids}
@@ -122,9 +168,7 @@ def start_downloads(percent=100, selected_ids=None, cache_base=None):
             rating = "0.0"
 
             # Download the MP3
-            mp3_url = rec.get("file", "")
-            if mp3_url:
-                download_mp3(xc_id, mp3_url, output_dir)
+            download_mp3(xc_id, recording_file_url(rec), output_dir)
 
             # Write CSV row
             row = {

--- a/tests/test_download_crows_xeno.py
+++ b/tests/test_download_crows_xeno.py
@@ -1,0 +1,88 @@
+import csv
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from downloader import download_crows_xeno as xc
+
+
+class FakeResp:
+    def __init__(self, payload, status=200, text=""):
+        self._payload = payload
+        self.status_code = status
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+RECORDINGS = [
+    {"id": "160878", "date": "2013-01-01", "lat": "47.6", "lng": "-122.3",
+     "rec": "A. Recordist", "rmk": "flight call", "file": "//xeno-canto.org/160878/download"},
+    {"id": "163637", "date": "2014-05-02", "lat": "48.1", "lng": "-121.9",
+     "rec": "B. Recordist", "rmk": "", "file": {"url": "https://xeno-canto.org/163637/download"}},
+    {"id": "999999", "date": "bad-date", "file": "//x/999999/download"},
+]
+
+
+def test_fetch_hits_v3_endpoint_with_key_and_tag_query(monkeypatch):
+    seen = {}
+
+    def fake_get(url, params=None, timeout=None):
+        seen["url"] = url
+        seen["params"] = params
+        return FakeResp({"numPages": 1, "recordings": RECORDINGS})
+
+    monkeypatch.setattr(xc.requests, "get", fake_get)
+    recs = xc.fetch_all_recordings(xc.SPECIES_QUERY, "TESTKEY")
+
+    assert seen["url"] == "https://xeno-canto.org/api/3/recordings"
+    assert seen["params"]["key"] == "TESTKEY"
+    assert seen["params"]["query"] == xc.SPECIES_QUERY
+    assert len(recs) == 3
+
+
+def test_recording_file_url_handles_string_dict_and_scheme():
+    assert xc.recording_file_url({"file": "//x/1/download"}) == "https://x/1/download"
+    assert xc.recording_file_url({"file": {"url": "https://x/2/download"}}) == "https://x/2/download"
+    assert xc.recording_file_url({"file": "https://x/3/download"}) == "https://x/3/download"
+    assert xc.recording_file_url({}) == ""
+
+
+def test_missing_key_skips_without_network(monkeypatch, capsys, tmp_path):
+    monkeypatch.delenv("XENO_CANTO_API_KEY", raising=False)
+
+    def boom(*args, **kwargs):
+        raise AssertionError("network must not be touched without a key")
+
+    monkeypatch.setattr(xc.requests, "get", boom)
+    xc.start_downloads(cache_base=str(tmp_path))
+
+    out = capsys.readouterr().out
+    assert "requires a free key" in out
+    assert "xeno-canto.org/account" in out
+
+
+def test_start_downloads_writes_catalog_and_applies_selection(monkeypatch, tmp_path):
+    monkeypatch.setattr(xc, "fetch_all_recordings", lambda query, key: RECORDINGS)
+    downloaded = []
+    monkeypatch.setattr(xc, "download_mp3",
+                        lambda xc_id, url, out: downloaded.append((xc_id, url)))
+
+    xc.start_downloads(selected_ids=["160878", "163637"],
+                       cache_base=str(tmp_path), api_key="TESTKEY")
+
+    csv_path = tmp_path / "libraries" / "xeno-canto" / "library.csv"
+    rows = list(csv.DictReader(open(csv_path, encoding="utf-8")))
+    ids = {r["ML Catalog Number"] for r in rows}
+
+    assert ids == {"160878", "163637"}
+    assert dict(downloaded) == {
+        "160878": "https://xeno-canto.org/160878/download",
+        "163637": "https://xeno-canto.org/163637/download",
+    }
+    notes = {r["ML Catalog Number"]: r["Media notes"] for r in rows}
+    assert notes["160878"] == "flight call"


### PR DESCRIPTION
The keyless v2 API no longer works: requests to
https://xeno-canto.org/api/2/recordings now return HTTP 404, so download_crows_xeno.py fetches nothing. The current v3 API requires a free key — a keyless request to
https://xeno-canto.org/api/3/recordings returns HTTP 401 with "Missing or invalid 'key' parameter". Switch to v3:

- Use https://xeno-canto.org/api/3/recordings with a required API key, read from the XENO_CANTO_API_KEY env var (or an api_key argument).
- Use the v3 tag-based query (gen:/sp:) instead of a free-text name.
- Resolve the audio URL defensively (file may be a string or {url: ...}).
- Skip Xeno-Canto with a clear notice when no key is set, so Macaulay downloads still succeed.
- Add key-free, network-free tests covering the endpoint, query, key handling, URL resolution, and catalog writing.

---
On a side note:
I am working on a similar project called cawtalker, which I am planning to open source soon! I'm using BirdNET embeddings as the representation and training a call-type classifier on top. If you want to chat about either of our projects or collaborate, feel free to email me: faerberbendev@protonmail.com